### PR TITLE
Spare gradle-wrapper.jar

### DIFF
--- a/templates/AndroidStudio.patch
+++ b/templates/AndroidStudio.patch
@@ -1,0 +1,1 @@
+!/gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
gradle-wrapper.jar is needed by gradlew. Not committing this file to Git can cause a "Could not find or load main class org.gradle.wrapper.GradleWrapperMain" error in CI.