### PR TITLE
Ignore google-services.json for Android Studio

### DIFF
--- a/templates/AndroidStudio.patch
+++ b/templates/AndroidStudio.patch
@@ -1,0 +1,2 @@
+# Google Services plugin
+google-services.json


### PR DESCRIPTION
The file contains OAuth related information and can always be downloaded from Google if lost.
More explainations on the file: https://developers.google.com/android/guides/google-services-plugin