### PR TITLE
Improve handling of VisualStudio Publish Profiles

### DIFF
--- a/templates/VisualStudio.gitignore
+++ b/templates/VisualStudio.gitignore
@@ -148,9 +148,11 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings
-# but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
+# TODO: Uncomment the next line to ignore your web deploy settings.
+# By default, sensitive information, such as encrypted password
+# should be stored in the .pubxml.user file.
+#*.pubxml
+*.pubxml.user
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to


### PR DESCRIPTION
.pubxml files were ignored to avoid checking in sensitive information, such as encrypted passwords. But encrypted passwords are stored in the .pubxml.user file. Sharing .pubxml files can be useful

See documentation: [How to: Edit Deployment Settings in Publish Profile (.pubxml) Files and the .wpp.targets File in Visual Studio Web Projects](https://msdn.microsoft.com/en-us/library/ff398069%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396#Editing%20Publish%20Profile%20(.pubxml)%20Files)

> The .pubxml.user file contains only a few settings that apply to a specific user, such as an encrypted password. By default it is not included in source control. 

(I also created a similar [pull request at github/gitignore](https://github.com/github/gitignore/pull/2387).)