### PR TITLE
Fix gitignore for QtCreator

### DIFF
--- a/templates/QtCreator.gitignore
+++ b/templates/QtCreator.gitignore
@@ -20,7 +20,7 @@
 *.creator
 
 # User project settings
-*.creator.user
+*.creator.user*
 
 # Qt Creator backups
 *.autosave


### PR DESCRIPTION
If the project was created in a different version of QtCreator will create a backup of the settings in the file:
*.creator.user(BlaBlaBla)