### PR TITLE
Ignore commonly generated auxiliary file

### DIFF
--- a/templates/TeX.gitignore
+++ b/templates/TeX.gitignore
@@ -37,6 +37,7 @@
 *.synctex.gz
 *.synctex.gz(busy)
 *.pdfsync
+*Notes.bib
 
 ## Auxiliary and intermediate files from other packages:
 # algorithms


### PR DESCRIPTION
pdflatex generates *filename*Notes.bib whenever the document class incorporates footnotes in the bibilography (commonly used, see e.g. the popular [revtex](https://www.ctan.org/pkg/revtex4-1) class).
Ignore this.