### PR TITLE
Fix "*.autosave" in Matlab gitignore

### DIFF
--- a/templates/Matlab.gitignore
+++ b/templates/Matlab.gitignore
@@ -19,4 +19,4 @@ slprj/
 octave-workspace
 
 # Simulink autosave extension
-.autosave
+*.autosave


### PR DESCRIPTION
Simulink (part of Matlab) generates $filename.slx.autosave files which are just backup copies. Because of a typo the gitignore did not match these.