### PR TITLE
Comment for excluding staticfiles/

### DIFF
--- a/templates/Django.gitignore
+++ b/templates/Django.gitignore
@@ -5,3 +5,7 @@ __pycache__/
 local_settings.py
 db.sqlite3
 media
+
+# If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
+# in your Git repository. Update and uncomment the following line accordingly.
+# <django-project-name>/staticfiles/


### PR DESCRIPTION
The staticfiles/ folder is generated by the `python manage.py collectstatic` management task and is similar to the node_modules/ folder. Teams with robust build processes that run `collectstatic` reliably will not want this folder committed to Git.