### PR TITLE
Add `+all` variants to JetBrains templates to ignore the whole .idea …

### DIFF
--- a/templates/AppCode+all.gitignore
+++ b/templates/AppCode+all.gitignore
@@ -1,0 +1,1 @@
+JetBrains+all.gitignore

--- a/templates/AppCode+all.patch
+++ b/templates/AppCode+all.patch
@@ -1,0 +1,1 @@
+JetBrains+all.patch

--- a/templates/CLion+all.gitignore
+++ b/templates/CLion+all.gitignore
@@ -1,0 +1,1 @@
+JetBrains+all.gitignore

--- a/templates/CLion+all.patch
+++ b/templates/CLion+all.patch
@@ -1,0 +1,1 @@
+JetBrains+all.patch

--- a/templates/Intellij+all.gitignore
+++ b/templates/Intellij+all.gitignore
@@ -1,0 +1,1 @@
+JetBrains+all.gitignore

--- a/templates/Intellij+all.patch
+++ b/templates/Intellij+all.patch
@@ -1,0 +1,1 @@
+JetBrains+all.patch

--- a/templates/JetBrains+all.gitignore
+++ b/templates/JetBrains+all.gitignore
@@ -1,0 +1,1 @@
+JetBrains.gitignore

--- a/templates/JetBrains+all.patch
+++ b/templates/JetBrains+all.patch
@@ -1,0 +1,4 @@
+# Ignores the whole idea folder
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/

--- a/templates/PhpStorm+all.gitignore
+++ b/templates/PhpStorm+all.gitignore
@@ -1,0 +1,1 @@
+JetBrains+all.gitignore

--- a/templates/PhpStorm+all.patch
+++ b/templates/PhpStorm+all.patch
@@ -1,0 +1,1 @@
+JetBrains+all.patch

--- a/templates/PyCharm+all.gitignore
+++ b/templates/PyCharm+all.gitignore
@@ -1,0 +1,1 @@
+JetBrains+all.gitignore

--- a/templates/PyCharm+all.patch
+++ b/templates/PyCharm+all.patch
@@ -1,0 +1,1 @@
+JetBrains+all.patch

--- a/templates/RubyMine+all.gitignore
+++ b/templates/RubyMine+all.gitignore
@@ -1,0 +1,1 @@
+JetBrains+all.gitignore

--- a/templates/RubyMine+all.patch
+++ b/templates/RubyMine+all.patch
@@ -1,0 +1,1 @@
+JetBrains+all.patch

--- a/templates/WebStorm+all.gitignore
+++ b/templates/WebStorm+all.gitignore
@@ -1,0 +1,1 @@
+JetBrains+all.gitignore

--- a/templates/WebStorm+all.patch
+++ b/templates/WebStorm+all.patch
@@ -1,0 +1,1 @@
+JetBrains+all.patch


### PR DESCRIPTION
…folder

Also adds corresponding aliases:

- AppCode
- CLion
- Intellij
- PhpStorm
- PyCharm
- RubyMine
- WebStorm