### PR TITLE
Comment out Pods (CocoaPods) directory by default

### DIFF
--- a/templates/CocoaPods.gitignore
+++ b/templates/CocoaPods.gitignore
@@ -3,4 +3,4 @@
 # CocoaPods - Only use to conserve bandwidth / Save time on Pushing
 #           - Also handy if you have a lage number of dependant pods
 #           - AS PER https://guides.cocoapods.org/using/using-cocoapods.html NEVER IGONRE THE LOCK FILE
-Pods/
+# Pods/


### PR DESCRIPTION
This seems to be a more reasonable default for the majority of cases.

See pros and cons here: https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control

Resolves #46 