### PR TITLE
Remove `yarn.lock` and `package-lock.json`.

### DIFF
--- a/templates/Node.gitignore
+++ b/templates/Node.gitignore
@@ -54,12 +54,6 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# Yarn Lock file
-yarn.lock
-
-# package.json Lock file
-package-lock.json
-
 # dotenv environment variables file
 .env
 


### PR DESCRIPTION
Resolve #45

`yarn.lock` and `package-lock.json` shoud be checked into source control.

### [`yarn.lock`](https://yarnpkg.com/lang/en/docs/yarn-lock/)
> All `yarn.lock` files should be checked into source control (e.g. git or mercurial). This allows Yarn to install the same exact dependency tree across all machines, whether it be your coworker’s laptop or a CI server.

### [`package-lock.json`](https://docs.npmjs.com/files/package-lock.json)
> This file is intended to be committed into source repositories, and serves various purposes