### PR TITLE
Remove Xcode from swift PM.

### DIFF
--- a/templates/SwiftPackageManager.gitignore
+++ b/templates/SwiftPackageManager.gitignore
@@ -1,5 +1,4 @@
 Packages
-.build
+.build/
 xcuserdata
-*.xcodeproj
 DerivedData/


### PR DESCRIPTION
Fixes https://github.com/joeblau/gitignore.io/issues/366

SwiftPM doesn't require Xcode and shouldn't have any Xcode specific ignore templates in here.