### PR TITLE
Ignore out/ recursively

### DIFF
--- a/templates/JetBrains+all.patch
+++ b/templates/JetBrains+all.patch
@@ -2,3 +2,7 @@
 # See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
 
 .idea/
+
+# The out folder may also exist in sub directories
+# In GitHub's .gitignore, it is only excluded at the top level
+out/


### PR DESCRIPTION
The out folder may also exist in sub directories. GitHub's .gitignore, it is only excluded at the top level.

Until https://github.com/github/gitignore/pull/2437 is merged, this PR provides a temporary solution.

