### PR TITLE
Android studio fixes

### DIFF
--- a/templates/Android.gitignore
+++ b/templates/Android.gitignore
@@ -43,9 +43,6 @@ captures/
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild
 
-# Google Services (e.g. APIs or Firebase)
-google-services.json
-
 # Freeline
 freeline.py
 freeline/

--- a/templates/Android.gitignore
+++ b/templates/Android.gitignore
@@ -40,9 +40,6 @@ captures/
 .idea/dictionaries
 .idea/libraries
 
-# Keystore files
-*.jks
-
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild
 

--- a/templates/AndroidStudio.gitignore
+++ b/templates/AndroidStudio.gitignore
@@ -95,7 +95,6 @@ Thumbs.db
 .mtj.tmp/
 
 # Package Files #
-*.jar
 *.war
 *.ear
 

--- a/templates/AndroidStudio.gitignore
+++ b/templates/AndroidStudio.gitignore
@@ -78,9 +78,6 @@ obj/
 .idea/dynamic.xml
 .idea/uiDesigner.xml
 
-# Keystore files
-*.jks
-
 # OS-specific files
 .DS_Store
 .DS_Store?

--- a/templates/AndroidStudio.patch
+++ b/templates/AndroidStudio.patch
@@ -1,4 +1,2 @@
-# Google Services plugin
-google-services.json
 
 !/gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
Fixing some issues in Android and Android Studio projects. 

1. *We shouldn't ignore the keystore (jks) files:*

If a project wants to store a keystore file in the project folders, let them. If developers don't want keystores going into git, they should make exception for their specific projects by either storing them out of the project and have gradle refer to it or add that gitignore rule to their project only. 

Several projects want to store keystore in their repo. Most of the times this is because you want to have specific keystores bound to the debug versions of your project so that the SHA is predictable and configurable with other services that use them.

2. *We shouldn't ignore the google-services.json files:*

These are usually files containing necessary data for Android projects to connect to Google's services (such as Maps). They are very much required by the projects. 

There could be cases where source is distributed, the author wishes not to distribute these files as they contain keys for the Google project. In those cases, the author should make exception to their specific project

3. *We shouldn't ignore jar files*

A lot of SDK developers publish their libraries in this format