### PR TITLE
Add Linux execution file extension

### DIFF
--- a/templates/PureBasic.gitignore
+++ b/templates/PureBasic.gitignore
@@ -13,3 +13,4 @@ project.cfg
 # Binary executables
 *.exe
 *.app
+*.out


### PR DESCRIPTION
The PureBasic creates the file "purebasic_compilation0.out" ("0" is a counter) on Linux, if
the program code is started directly from the PureBasic IDE. The file is a temporary
compilation that optionally contains debugger functions.

When the final compilation is created by the PureBasic IDE, the compilation has no file
extension.