### PR TITLE
Remove patch included in upstream

### DIFF
--- a/templates/JetBrains+all.patch
+++ b/templates/JetBrains+all.patch
@@ -2,7 +2,3 @@
 # See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
 
 .idea/
-
-# The out folder may also exist in sub directories
-# In GitHub's .gitignore, it is only excluded at the top level
-out/


### PR DESCRIPTION
Follow up to https://github.com/dvcs/gitignore/pull/54 - in upstream, the update was included faster than light.