### PR TITLE
Add build folder for CMake

### DIFF
--- a/templates/CMake.gitignore
+++ b/templates/CMake.gitignore
@@ -7,3 +7,4 @@ cmake_install.cmake
 install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
+build


### PR DESCRIPTION
Usually CMake builds are performed in a folder called `build` that also shouldn't be tracked