### PR TITLE
Added CodeKit v3 reference.

### DIFF
--- a/templates/CodeKit.gitignore
+++ b/templates/CodeKit.gitignore
@@ -1,3 +1,4 @@
 # General CodeKit files to ignore
 config.codekit
+config.codekit3
 /min


### PR DESCRIPTION
The original CodeKit ref "config.codekit" works ok for versions 1 - 2 but version 3 uses the specific "config.codekit3" ref.