### PR TITLE
Add support for HomeAssistant

### DIFF
--- a/templates/HomeAssistant.gitignore
+++ b/templates/HomeAssistant.gitignore
@@ -1,0 +1,29 @@
+# Files with personal details*.crt
+*.csr
+*.key
+/icloud/*
+harmony_media_room.conf
+home-assistant_v2.db
+home-assistant_v2.db-*
+html5_push_registrations.conf
+ip_bans.yaml
+known_devices.yaml
+phue.conf
+plex.conf
+pyozw.sqlite
+secrets.yaml
+tradfri.conf
+
+# Temporary files
+*.db-journal
+*.pid
+tts
+
+# automatically downloaded dependencies
+deps
+lib
+www
+
+# Log files
+home-assistant.log
+ozw_log.txt

--- a/templates/HomeAssistant.gitignore
+++ b/templates/HomeAssistant.gitignore
@@ -2,8 +2,12 @@
 *.crt
 *.csr
 *.key
-/icloud/*
+.google.token
+.uuid
+icloud/
+google_calendars.yaml
 harmony_media_room.conf
+home-assistant.db
 home-assistant_v2.db
 home-assistant_v2.db-*
 html5_push_registrations.conf
@@ -28,3 +32,6 @@ www
 # Log files
 home-assistant.log
 ozw_log.txt
+
+# Development files
+custom_components/

--- a/templates/HomeAssistant.gitignore
+++ b/templates/HomeAssistant.gitignore
@@ -1,4 +1,5 @@
-# Files with personal details*.crt
+# Files with personal details
+*.crt
 *.csr
 *.key
 /icloud/*


### PR DESCRIPTION
Add support for HomeAssistant, based on the suggested gitignore in [their documentation](https://home-assistant.io/docs/ecosystem/backup/backup_github/).