### PR TITLE
Exclude .rakeTasks file generated by Ruby IntelliJ plugin

### DIFF
--- a/templates/JetBrains.gitignore
+++ b/templates/JetBrains.gitignore
@@ -42,6 +42,9 @@ atlassian-ide-plugin.xml
 # Cursive Clojure plugin
 .idea/replstate.xml
 
+# Ruby plugin and RubyMine
+/.rakeTasks
+
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties


### PR DESCRIPTION
Generated file looks something like:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Settings><!--This file was automatically generated by Ruby plugin.
You are allowed to: 
1. Remove rake task
2. Add existing rake tasks
To add existing rake tasks automatically delete this file and reload the project.
--><RakeGroup><RakeTask/></RakeGroup></Settings>
```

See this [StackOverflow](https://stackoverflow.com/questions/9645481/rails-and-rake-raketasks) post for more information since the [official documentation](https://www.jetbrains.com/help/ruby/running-rake-tasks.html) does not go into detail about the generated file.