### PR TITLE
Add files that will be created during building

### DIFF
--- a/templates/OpenFOAM.gitignore
+++ b/templates/OpenFOAM.gitignore
@@ -38,3 +38,10 @@ constant/triSurface
 # function object and post-processing data
 forces
 postProcessing
+
+# Needed when C++ code is built using the OpenFOAM library, since it does not
+# use a "normal" build tool (make, cmake, ..).
+lnInclude
+*.dep
+linux*
+Darwin*


### PR DESCRIPTION
These files are created during the build process of ``wmake``, used to
build OpenFOAM. When building a custom library, it is handy to get
them ignored as well.