### PR TITLE
Update Laravel to only ignore the root vendor directory

### DIFF
--- a/templates/Laravel.gitignore
+++ b/templates/Laravel.gitignore
@@ -1,4 +1,4 @@
-vendor/
+/vendor
 node_modules/
 npm-debug.log
 


### PR DESCRIPTION
Laravel's [own .gitignore](https://github.com/laravel/laravel/blob/12db5051228e4211f788f69da725c3ee8603fa62/.gitignore) only ignores /vendor, and when assets from packages are published, such as in /resources/views and /public, they are placed into a vendor directory, such as in [Laravel Cashier](https://github.com/laravel/cashier) or [Laravel Datatables](https://github.com/yajra/laravel-datatables).