### PR TITLE
Vagrant: ignore .box files

### DIFF
--- a/templates/Vagrant.gitignore
+++ b/templates/Vagrant.gitignore
@@ -1,1 +1,2 @@
 .vagrant/
+*.box


### PR DESCRIPTION
exclude any output .box files created by vagrant package