### PR TITLE
Go: Do not ignore vendor/

### DIFF
--- a/templates/Go.gitignore
+++ b/templates/Go.gitignore
@@ -12,6 +12,3 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
-
-# Golang project vendor packages which should be ignored
-vendor/


### PR DESCRIPTION
I'm not sure why a sensible person would ignore vendor/ directory.
Checking it in to the source control is the whole point of having
this directory.