### PR TITLE
packer: ignore *.vdi's

### DIFF
--- a/templates/Packer.gitignore
+++ b/templates/Packer.gitignore
@@ -3,3 +3,6 @@ packer_cache/
 
 # For built boxes
 *.box
+
+# For build artifacts
+*.vdi


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Most packer builds generate VirtualBox *.vdi files, which should be excluded from version control in addition to other build artifacts.