### PR TITLE
packer: ignore temporary artifacts

### DIFF
--- a/templates/Packer.gitignore
+++ b/templates/Packer.gitignore
@@ -1,5 +1,6 @@
 # Cache objects
 packer_cache/
+output-*/
 
 # For built boxes
 *.box


### PR DESCRIPTION
ignore temporary artifacts placed in output-virtualbox-iso/, output-vmware-iso/, output-qemu/, etc.

### Update

- [x] Template - Update existing `.gitignore` template

## Details

See https://www.packer.io/docs/builders/virtualbox-iso.html#output_directory for more detail.