### PR TITLE
Use more relaxed vim swap regexes

### DIFF
--- a/templates/Vim.gitignore
+++ b/templates/Vim.gitignore
@@ -1,8 +1,6 @@
 # swap
-[._]*.s[a-v][a-z]
-[._]*.sw[a-p]
-[._]s[a-v][a-z]
-[._]sw[a-p]
+.sw[a-p]
+.*.sw[a-p]
 # session
 Session.vim
 # temporary


### PR DESCRIPTION

- [X ] Template - Update existing `.gitignore` template

## Details

See https://unix.stackexchange.com/a/326894 and related answers.
We also prefix the regex with a `.` because vim does this on every non
MS-DOS-like filesystems.

Examples of excluded files:
  * .swp
  * .swo
  * .test.sh.swp
  * .test.sh.swo

Examples of included files:
  * .ssh/config
  * test.sh.swp

Fixes [this issue](https://github.com/joeblau/gitignore.io/issues/386).