### PR TITLE
add leading "*" to match filename.ext

### DIFF
--- a/templates/SAS.gitignore
+++ b/templates/SAS.gitignore
@@ -1,14 +1,14 @@
 # Binary data formats
-.sas7baud
-.sas7bdat
-.sas7bvew
-.sas7bndx
-.sas7bcat
-.sas7bacs
-.sas7bfdb
-.sas7bmdb
-.sas7bdmd
-.sas7bitm
-.sas7butl
-.sas7bput
-.sas7bbak
+*.sas7baud
+*.sas7bdat
+*.sas7bvew
+*.sas7bndx
+*.sas7bcat
+*.sas7bacs
+*.sas7bfdb
+*.sas7bmdb
+*.sas7bdmd
+*.sas7bitm
+*.sas7butl
+*.sas7bput
+*.sas7bbak


### PR DESCRIPTION
Usually SAS generates those files with filename. A "*" is needed to match filename.ext

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

SAS generates binary files with filename.ext format, and add leading "*" to match it.