### PR TITLE
Remove Django from Python

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -49,10 +49,6 @@ coverage.xml
 *.mo
 *.pot
 
-# Django stuff:
-*.log
-local_settings.py
-
 # Flask stuff:
 instance/
 .webassets-cache


### PR DESCRIPTION
### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Django has its own template, which is more comprehensive
