### PR TITLE
ignore pytest cache files

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache/
 nosetests.xml
 coverage.xml
 *.cover


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Pytest stores various information like `.pytest_cache/v/cache/lastfailed` in `.pytest_cache`. As this should not be shared with other developers, ignore that directory.

https://docs.pytest.org/en/latest/cache.html#inspecting-cache-content