### PR TITLE
Add bib2gls output files to TeX/glossaries

### DIFF
--- a/templates/LaTeX.patch
+++ b/templates/LaTeX.patch
@@ -1,0 +1,1 @@
+TeX.patch

--- a/templates/TeX.patch
+++ b/templates/TeX.patch
@@ -1,0 +1,2 @@
+# glossaries
+*.glstex


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [X] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

The LaTeX glossaries package contains the `bib2gls` tool, which outputs a `$name.glstex` file. These are missing from the github template. See the [glossaries-extra documentation, page 120](http://mirrors.ctan.org/macros/latex/contrib/glossaries-extra/glossaries-extra-manual.pdf#page=120) for details.