### PR TITLE
Update Crystal gitignore

### DIFF
--- a/templates/Crystal.gitignore
+++ b/templates/Crystal.gitignore
@@ -1,7 +1,8 @@
-/doc/
+/docs/
 /lib/
 /bin/
 /.shards/
+*.dwarf
 
 # Libraries don't need dependency lock
 # Dependencies will be locked in application that uses them


### PR DESCRIPTION
Docs directory has changed and dwarf debug files were added to the default gitignore template, see https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/tools/init/template/gitignore.ecr