### PR TITLE
Go: Added *.exe~ and removed .glide/

### DIFF
--- a/templates/Go.gitignore
+++ b/templates/Go.gitignore
@@ -1,5 +1,6 @@
 # Binaries for programs and plugins
 *.exe
+*.exe~
 *.dll
 *.so
 *.dylib
@@ -9,6 +10,3 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
-# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
-.glide/


### PR DESCRIPTION
# Pull Request

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [X] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Updated the `.gitignore` file like the one from the official GitHub gitignore repository: https://github.com/github/gitignore/blob/master/Go.gitignore

In detail:
- [Added `*.exe~`](https://github.com/github/gitignore/commit/b25db7156bc4a76f4380c72965bdf4178a2aa920#diff-37de91c3b83b42cd0579f8215296ad6f)
- [Removed `.glide/`](https://github.com/github/gitignore/commit/3bb1ab44b38f529fc29efa40e04534eb0cf0b788#diff-37de91c3b83b42cd0579f8215296ad6f)