### PR TITLE
Added default annotation processing folder to Eclipse.patch

### DIFF
--- a/templates/Eclipse.patch
+++ b/templates/Eclipse.patch
@@ -3,3 +3,6 @@
 
 # JDT-specific (Eclipse Java Development Tools)		
 .classpath
+
+# Annotation Processing
+.apt_generated


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The `.apt_generated` folder is the default folder when using annotation processing in Eclipse. Even if this configuration can be customized, just activating annotation processing (e.g. through a third-party tool like Gradle) will automatically create this folder and put generated source files there. Any files generated (and reproducible) from source files should **not** be managed by Git.

Related: http://help.eclipse.org/kepler/index.jsp?topic=%2Forg.eclipse.jdt.doc.isv%2Fguide%2Fjdt_apt_getting_started.htm

**Please note:** I added an equivalent [pull request](https://github.com/github/gitignore/pull/2649) to **github/gitignore**, which may be relevant.