### PR TITLE
Ignore more artifcats related to Clojure tooling

### DIFF
--- a/templates/Clojure.gitignore
+++ b/templates/Clojure.gitignore
@@ -6,8 +6,10 @@ pom.xml.asc
 /classes/
 /target/
 /checkouts/
+/.shadow-cljs/
 .lein-deps-sum
 .lein-repl-history
 .lein-plugins/
 .lein-failures
 .nrepl-port
+.rebel_readline_history


### PR DESCRIPTION
Ignores artifacts from shadow-cljs (a ClojureScript compiler similar to Figwheel) and rebel-readline (a nice Clojure(Script) REPL). Both are fairly widespread in the community (even though this is a subjective statement).

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Repositories on GitHub:  

* https://github.com/thheller/shadow-cljs  
* https://github.com/bhauman/rebel-readline