### PR TITLE
Added the contents of directories not indexed by Spotlight to the macOS-template

### DIFF
--- a/templates/macOS.gitignore
+++ b/templates/macOS.gitignore
@@ -8,6 +8,10 @@ Icon
 # Thumbnails
 ._*
 
+# Contents of directories not indexed by Spotlight
+# https://developer.apple.com/library/content/qa/qa1497/_index.html
+*.noindex/**
+
 # Files that might appear in the root of a volume
 .DocumentRevisions-V100
 .fseventsd


### PR DESCRIPTION
# Pull Request

### New
- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [x] Patch - Template extending functionality of existing template

## Details
If someone adds a ".noindex" suffix to a folder on macOS to exclude it from Spotlight, they probably don't want the files in it to be tracked by git either, let's make it so.