### PR TITLE
.gitignore for Zuken CR8000 PCB design environment

### DIFF
--- a/templates/ZukenCR8000.gitignore
+++ b/templates/ZukenCR8000.gitignore
@@ -1,0 +1,76 @@
+## Zuken Global
+
+# log files
+*.log
+
+
+## Schematic
+
+# Schematic lock / edit in progress files
+*.s_t
+
+# Schematic Sheet backups
+*.shtb
+*.shtq
+
+# Schematic Design backups
+*undo.dsgn_
+
+# Schematic ERC/DRC results
+**/*template.cir/drc*
+
+# Schematic Frame
+**/*template.cir/frame*
+
+# Schematic log
+**/*template.cir/log*
+
+# Schematic exported netlist readme
+**/*template.cir/ext/readme.txt
+
+
+## Schematic <-> Layout communication
+
+# forward annotation files:
+*.coh
+*.loh
+*.coe
+
+
+## Layout
+
+# Layout Backups
+*.dsgn.bk
+
+# Layout Lockfiles
+*.dsgn.lk
+
+# Layout .crdb folder
+**/.crdb/
+
+# Layout .df_cache folder
+**/.df_cache/
+
+# Layout Automatic backup folders
+**/*dsgn.autobk/
+
+# Layout DRC result folder
+**/*.chk/
+
+# Layout Parameter file folders
+**/*.dsgn.prm/
+
+# Layout Signal Integrity result folders
+**/*.si/
+
+# Layout Power Integrity / EMI result folders
+**/*.emc/
+
+
+## DFM
+
+# DFM backups
+*.mdgn.bk
+
+# DFM lockfiles
+*.mdgn.lk


### PR DESCRIPTION
Ignore file for Zuken CR8000 Schematic, PCB and DFM environment. Library management not covered yet.

# Pull Request

### New

- [X] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

## Details

No public information/documentation available, 
information extracted from program help files.