### PR TITLE
Add galaxy info installation file

### DIFF
--- a/templates/Ansible.gitignore
+++ b/templates/Ansible.gitignore
@@ -1,1 +1,2 @@
 *.retry
+.galaxy_install_info


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The file `meta/.galaxy_install_info` is autogenerated when you install
Ansible role using galaxy. 