### PR TITLE
Remove one trailing slash

### DIFF
--- a/templates/R.gitignore
+++ b/templates/R.gitignore
@@ -15,7 +15,7 @@
 /*.Rcheck/
 
 # RStudio files
-.Rproj.user/
+.Rproj.user
 
 # produced vignettes
 vignettes/*.html


### PR DESCRIPTION
### Update

- [x] Template - Update existing `R.gitignore` template

## Details

If the trailing slash is not removed, `RStudio` will add one entry (i.e., .`Rproj.user`) each time the R project opens.
