### PR TITLE
Add bookdown rendered files to ignore template

### DIFF
--- a/templates/Bookdown.gitignore
+++ b/templates/Bookdown.gitignore
@@ -1,0 +1,2 @@
+# R package: bookdown caching files
+/*_files/


### PR DESCRIPTION
### Update

- [x] Template - Update existing `R.gitignore` template

## Details

`bookdown` also uses `/*_files/` folder to store caching images.
