### PR TITLE
Add /vendor and /Godeps directory

### DIFF
--- a/templates/Go.gitignore
+++ b/templates/Go.gitignore
@@ -10,7 +10,3 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
-# Dependency directories
-/vendor/
-/Godeps/

--- a/templates/Go.gitignore
+++ b/templates/Go.gitignore
@@ -10,3 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Dependency directories
+/vendor/
+/Godeps/

--- a/templates/Go.patch
+++ b/templates/Go.patch
@@ -1,0 +1,2 @@
+/vendor/
+/Godeps/


### PR DESCRIPTION
Hi there :wave: 

Would it be cool to add the dependency directories of tools like [godep](https://github.com/tools/godep) and [dep](https://github.com/golang/dep). I feel like these tools are so commonly used that the folders can be ignored by default.

I'm open to suggestions though :see_no_evil: 