### PR TITLE
Add the 'bin' dir to Python gitignore

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+bin/
 build/
 develop-eggs/
 dist/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

When using `virtualenv`, the tool creates a `./bin/` folder containing the `activate`, `python`, `pip`, etc. scripts/binaries. These shouldn't be included into the projects source code.
