### PR TITLE
Ignore VS2015/2017 cache files in OpenFrameworks.gitignore

### DIFF
--- a/templates/OpenFrameworks.gitignore
+++ b/templates/OpenFrameworks.gitignore
@@ -42,6 +42,17 @@ xcuserdata
 *.ilk
 *.aps
 ipch/
+.vs/
+*.aps
+*.ncb
+*.opendb
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+*.psess
+*.vsp
+*.vspx
+*.sap
 
 # Eclipse
 .metadata

--- a/templates/OpenFrameworks.gitignore
+++ b/templates/OpenFrameworks.gitignore
@@ -43,7 +43,6 @@ xcuserdata
 *.aps
 ipch/
 .vs/
-*.aps
 *.ncb
 *.opendb
 *.cachefile


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template (OpenFrameworks.gitignore)

## Details

I noticed that some of the folders VS2017 generates were not being ignored by the current gitignore file; hence, I am adding some extra ignore paths cherry-picked from `VisualStudio.gitignore`