### PR TITLE
Add sts4-cache folder to eclipse gitignore template

### DIFF
--- a/templates/Eclipse.gitignore
+++ b/templates/Eclipse.gitignore
@@ -43,6 +43,7 @@ local.properties
 
 # STS (Spring Tool Suite)
 .springBeans
+.sts4-cache/
 
 # Code Recommenders
 .recommenders/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Newer Spring Tool Suite versions create a `.sts4-cache` folder in the project root. This adds this to gitignore, in order to avoid this folder to be part of version control