### PR TITLE
OpenFOAM: excluding important folders and files

### DIFF
--- a/templates/OpenFOAM.gitignore
+++ b/templates/OpenFOAM.gitignore
@@ -25,6 +25,7 @@ constant/polyMesh/owner*
 constant/polyMesh/neighbour*
 constant/polyMesh/boundary*
 constant/polyMesh/sets
+constant/polyMesh/*
 
 # Zones and levels
 *Level*
@@ -45,3 +46,10 @@ lnInclude
 *.dep
 linux*
 Darwin*
+
+#exclude important folders and files:
+!0/
+!constant/thermophysicalProperties
+!constant/turbulenceProperties
+!system/
+!.gitignore


### PR DESCRIPTION
# Pull Request

### Update

- [ ] Template - Update existing `.gitignore` template

## Details
Following [ this discussion](http://disq.us/p/1v92ume), IMHO it is easier to exclude the important files and folders:

    *
    !0/
    !constant/thermophysicalProperties
    !constant/turbulenceProperties
    !system/
    !.gitignore

instead of all the files above. This will make the gitignore file way more concise. 