### PR TITLE
Allow gitignore files inside the instance/ folder

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -57,7 +57,8 @@ local_settings.py
 db.sqlite3
 
 # Flask stuff:
-instance/
+instance/*
+!instance/.gitignore
 .webassets-cache
 
 # Scrapy stuff:


### PR DESCRIPTION
# Pull Request

### Update

- [x] Template - Update existing `.gitignore` template

## Details

As of Flask v1, depending on your application setup you might need
the instance folder to exist. To avoid the extra boilerplate of creating
the instance folder from the application itself, this commit introduces
a rule to allow gitignore files to reside in the instance folder