### PR TITLE
Update Polymer.gitignore

### DIFF
--- a/templates/Polymer.gitignore
+++ b/templates/Polymer.gitignore
@@ -1,2 +1,8 @@
 #Installed components via bower
 bower_components/
+
+#Installed modules via npm
+node_modules/
+
+#Polymer-cli builds
+build/


### PR DESCRIPTION
Polymer 3 uses Yarn/NPM instead of Bower, and produces builds in a new `build` directory

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

https://www.polymer-project.org/3.0/docs/tools/create-app-polymer-cli
https://www.polymer-project.org/3.0/docs/tools/create-element-polymer-cli
https://www.polymer-project.org/3.0/toolbox/build-for-production