### PR TITLE
Ignore Xcode build system configuration

### DIFF
--- a/templates/Xcode.patch
+++ b/templates/Xcode.patch
@@ -3,3 +3,4 @@
 !*.xcodeproj/xcshareddata/
 !*.xcworkspace/contents.xcworkspacedata
 /*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings


### PR DESCRIPTION
# Pull Request

### Update

- [x] Patch - Update existing `.gitignore` template

## Details

- The new build system that is shipped along side with Xcode 10 [is breaking development pods](https://github.com/CocoaPods/CocoaPods/issues/8102#issuecomment-422454499).
- It turns out that the decision of which build system to use is configured per `project/workspace` base in a settings file named `WorkspaceSettings.xcsettings`.
- Xcode does that even if one check's the `Per-User Workspace Settings`. What is worst, it creates an empty file ¯\_(ツ)_/¯

![image](https://user-images.githubusercontent.com/7672056/46111275-bfc26280-c1bc-11e8-8dc0-3ca14f55f1ef.png)

- IMHO this file should not be tracked by `git` because it may break CI or other team members that are not using Xcode 10 just yet.