### PR TITLE
Ignore netbeans-private properties in nested projects

### DIFF
--- a/templates/NetBeans.gitignore
+++ b/templates/NetBeans.gitignore
@@ -1,4 +1,4 @@
-nbproject/private/
+**/nbproject/private/
 build/
 nbbuild/
 dist/


### PR DESCRIPTION
Ignoring without ** is not enough for nested projects and ignore
paths includind several direcotries.

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Ignoring without ** is not enough for nested projects and ignore
paths including several direcotries.