### PR TITLE
Ignore config file for Android Studio's Vector Asset Studio

### DIFF
--- a/templates/AndroidStudio.gitignore
+++ b/templates/AndroidStudio.gitignore
@@ -79,6 +79,7 @@ obj/
 .idea/sqlDataSources.xml
 .idea/dynamic.xml
 .idea/uiDesigner.xml
+.idea/assetWizardSettings.xml
 
 # OS-specific files
 .DS_Store


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template

## Details

This configuration file simply stores the previous state of the Vector Asset Studio wizard. Definitely ignorable.