### PR TITLE
add expo ignores in ReactNative gitignore

### DIFF
--- a/templates/ReactNative.gitignore
+++ b/templates/ReactNative.gitignore
@@ -1,1 +1,4 @@
 # React Native Stack Base
+
+.expo
+__generated__


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

I think ReactNative should include expo gitignore. [expo gitignore].(https://github.com/expo/expo/blob/master/.gitignore)

*replace this section with links and/or info about the proposed request*