### PR TITLE
Update Godot gitignore for Godot 3.x

### DIFF
--- a/templates/Godot.gitignore
+++ b/templates/Godot.gitignore
@@ -3,6 +3,7 @@
 .import/
 export.cfg
 export_presets.cfg
+*.*.import
 
 # Mono-specific ignores
 .mono/


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Godot 3.x has import files living alongside the asset itself with ".import" appended, such as "texture.png.import". This change adds support for this new pattern while still supporting the Godot 2.x pattern with a dedicated .import/ subdirectory.