### PR TITLE
Remove Python.VirtualEnv.stack

### DIFF
--- a/templates/Python.VirtualEnv.stack
+++ b/templates/Python.VirtualEnv.stack
@@ -1,1 +1,0 @@
-VirtualEnv.gitignore


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

I am proposing/requesting that the VirtualEnv template not be a default part of the Python stack.

* Many of the directories added by VirtualEnv are legitimate names in many Python projects. In particular, `bin` `scripts` are not uncommon in a Python project. 
* The link cited by `VirtualEnv.gitignore` for documentation, http://iamzed.com/2009/05/07/a-primer-on-virtualenv/, now 404's.
* Modern virtual environment practices are to put your virtual environment in a self-contained directory. The most common choice is `venv/`, which is already in `Python.gitignore` along with other common choices: `env/` and `ENV/`. Every file in `VirtualEnv.gitignore` will be contained within the `venv/` directory.
* This is also the practice suggested by both the older `virtualenv` ([Docs](https://virtualenv.pypa.io/en/latest/userguide/)) and the newer `venv` ([Docs](https://docs.python.org/3/library/venv.html#creating-virtual-environments))
