### PR TITLE
Exclude D test binaries

### DIFF
--- a/templates/D.gitignore
+++ b/templates/D.gitignore
@@ -13,6 +13,8 @@
 
 # Executables
 *.exe
+# Test Executables
+*-test-*
 
 # DUB
 .dub

--- a/templates/D.gitignore
+++ b/templates/D.gitignore
@@ -21,6 +21,8 @@
 docs.json
 __dummy.html
 docs/
+# Comment to allow dub lock file to be version controlled as well
+dub.selections.json
 
 # Code coverage
 *.lst


### PR DESCRIPTION
Prevent binary artifacts produced by dmd -unittest, dub test, etc., from appearing in version control

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Unfortunately, the way that dub/dmd runs unit tests is by producing a binary named `<project>-test-<config>[.exe]`, at the top-level of a project. The file is not much use in release bundles, it's just how D provides a launching point for any unit tests. In the long run, these files would be better placed in `.dub/`, but for now we can simply exclude the pattern from version control and continue coding.