### PR TITLE
do not ignore the project file!

### DIFF
--- a/templates/CodeBlocks.gitignore
+++ b/templates/CodeBlocks.gitignore
@@ -1,7 +1,6 @@
 # specific to CodeBlocks IDE
 *.layout
 *.depend
-*.cbp
 # generated directories
 bin/
 obj/


### PR DESCRIPTION
Ignoring the project file would be self-defeating. The point of a gitignore is to ignore generated files, not files that are crucial to compiling correctly (for example, a Visual Studio gitignore doesn't say to ignore *.sln, but does say to ignore *.sln.docstates).

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

*replace this section with links and/or info about the proposed request*