### PR TITLE
Move SonarLint line from JetBrains.patch to JetBrains.gitignore

### DIFF
--- a/templates/JetBrains.gitignore
+++ b/templates/JetBrains.gitignore
@@ -64,3 +64,6 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Sonarlint plugin
+.idea/sonarlint

--- a/templates/JetBrains.patch
+++ b/templates/JetBrains.patch
@@ -4,6 +4,3 @@
 # modules.xml
 # .idea/misc.xml
 # *.ipr
-
-# Sonarlint plugin
-.idea/sonarlint


### PR DESCRIPTION
This makes the SonarLint ignore also appear in derived templates.

# Pull Request
- [X] Template - Update existing `.gitignore` template