### PR TITLE
autotools: encourage fewer generated sources to be version controlled

### DIFF
--- a/templates/Autotools.gitignore
+++ b/templates/Autotools.gitignore
@@ -1,6 +1,10 @@
 # http://www.gnu.org/software/automake
 
+# Generated source files
+# configure
+# Makefile
 Makefile.in
+
 /ar-lib
 /mdate-sh
 /py-compile


### PR DESCRIPTION
I know autotools has a historical convention of checking configure and Makefile into version control, so that downstream users "benefit" from not having to install the autotools. But I wonder if it is time to change this. Perhaps it would be more rigorous to actually expect users to `autoreconf && ./configure && make && [sudo] make install`. These files are not meant to be hand-edited, and a good way to communicate that is to keep them out of version control.

### Update

- [x] Template - Update existing `.gitignore` template

## Details

An opinionated take on how autotools should be used, specifically questioning the idea that `autoreconf` be reserved for maintainers, and that users should interact directly with the configure and Makefile scripts. I understand this differs from how 99.9999% of autotools projects work, but I thought it's worth discussing.

Maybe we leave these file patterns in the gitignore, but leave them commented out by default?