### PR TITLE
cmake: exclude external project build directories

### DIFF
--- a/templates/CMake.gitignore
+++ b/templates/CMake.gitignore
@@ -1,3 +1,6 @@
+# External projects
+*-prefix/
+
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles


### PR DESCRIPTION
### Update

- [x] Template - Update existing `.gitignore` template

## Details

https://cmake.org/cmake/help/latest/module/ExternalProject.html

In practice, cmake uses a path like `<project name>-prefix` for building external projects.