### PR TITLE
KiCad: updated files to KiCad 5.0.x format and added extra files

### DIFF
--- a/templates/KiCad.gitignore
+++ b/templates/KiCad.gitignore
@@ -12,6 +12,7 @@ _autosave-*
 *-rescue.lib
 *-save.pro
 *-save.kicad_pcb
+rescue-backup/
 
 # Netlist files (exported from Eeschema)
 *.net
@@ -23,3 +24,8 @@ _autosave-*
 # Exported BOM files
 *.xml
 *.csv
+*.tsv
+bom/
+
+# Gerber export output
+out/


### PR DESCRIPTION
- added "rescue-backup" folder
- added "*.tsv" and "bom" for BoM related ignores
- added "out" folder for GRB exports

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X ] Template - Update existing `.gitignore` template

## Details

Updated ignored files to KiCad 5.0.x version