### PR TITLE
fix pyenv

### DIFF
--- a/templates/Python.gitignore
+++ b/templates/Python.gitignore
@@ -78,9 +78,6 @@ target/
 profile_default/
 ipython_config.py
 
-# pyenv
-.python-version
-
 # celery beat schedule file
 celerybeat-schedule
 


### PR DESCRIPTION
pyenv expects .python-version files to be in place; these are small and good to check into VCS.

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Fix for pyenv, which wants to find .python-version files. These are typically hand written, not auto-generated.