### PR TITLE
Ignore all build directories with Gradle template

### DIFF
--- a/templates/Gradle.gitignore
+++ b/templates/Gradle.gitignore
@@ -1,5 +1,5 @@
 .gradle
-/build/
+build/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

The Gradle gitignore template currently ignores **/build/**. Due to the prefixed slash, this only ignores the build directory of the root project. However, Gradle supports [multi-project builds](https://docs.gradle.org/current/userguide/multi_project_builds.html), which have their own build directories. To ignore these as well, this PR removes the prefixed slash.