### PR TITLE
Unity - Explicitly include meshes in .obj format

### DIFF
--- a/templates/Unity.gitignore
+++ b/templates/Unity.gitignore
@@ -10,6 +10,9 @@
 # Never ignore Asset meta data
 !/[Aa]ssets/**/*.meta
 
+# Never ignore meshes in Wavefront .obj format (often excluded from a global ignore file)
+![Aa]ssets/**/*.obj
+
 # Uncomment this line if you wish to ignore the asset store tools plugin
 # /[Aa]ssets/AssetStoreTools*
 


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

Wavefront object format is a commonly used exchange format between 3D modelling applications, but the .obj extension is commonly excluded in global exclude files, because files with the same extension are auto-generated when compiling code.
