### PR TITLE
Include msbuild.rsp

### DIFF
--- a/templates/VisualStudio.gitignore
+++ b/templates/VisualStudio.gitignore
@@ -76,6 +76,7 @@ StyleCopReport.xml
 *.pgc
 *.pgd
 *.rsp
+!msbuid.rsp #override command line options when building with msbuild.
 *.sbr
 *.tlb
 *.tli


### PR DESCRIPTION
## New or update

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [X] Template - Update existing `.gitignore` template

## Details

If you need to mess with the msbuild paramaters in for example CI/CD, this is the default response file. Nothing autogenerates it. I'd actually consider removing the `*.rsp ine` but perhaps Visual C++ or some obscure VS tool generates these files.
