### PR TITLE
Update VisualStudioCode.gitignore

### DIFF
--- a/templates/VisualStudioCode.gitignore
+++ b/templates/VisualStudioCode.gitignore
@@ -1,4 +1,4 @@
-.vscode/*
+.vscode
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json


### PR DESCRIPTION
`.vscode/*` doesn't actually exclude the .vscode directory, but with this change it does.

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Current template does not exclude .vscode directory. Nevertheless, removing the trailing `/*` chars fixes it.

Thanks very much for maintaining these!! Very helpful stuff :)