### PR TITLE
Add WASM file extensions

### DIFF
--- a/templates/Web.gitignore
+++ b/templates/Web.gitignore
@@ -8,4 +8,6 @@
 *.jsp
 *.php
 *.rss
+*.wasm
+*.wat
 *.xhtml


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Web Assembly file extensions are missing from the Web gitignore.
Web Assembly Text Format: https://webassembly.org/docs/text-format/
Web Assembly Binary Encoding: https://webassembly.org/docs/binary-encoding/