### PR TITLE
Added opt-in pattern for SwiftPM’s new Xcode integration directory

### DIFF
--- a/templates/Swift.gitignore
+++ b/templates/Swift.gitignore
@@ -39,6 +39,8 @@ playground.xcworkspace
 # Package.pins
 # Package.resolved
 .build/
+# Add this line if you want to avoid checking in Xcode SPM integration.
+# .swiftpm/xcode
 
 # CocoaPods
 #


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

With Xcode 11 Apple added Xcode integration to SwiftPM, which creates an invisible `.swiftpm/xcode` directory:
```
└── .swiftpm
    └── xcode
        ├── package.xcworkspace
        │   ├── contents.xcworkspacedata
        │   ├── xcshareddata
        │   │   └── IDEWorkspaceChecks.plist
        │   └── xcuserdata
        │       └── <username>.xcuserdatad
        │           └── UserInterfaceState.xcuserstate
        └── xcuserdata
            └── <username>.xcuserdatad
                └── xcschemes
                    └── xcschememanagement.plist
```

While it should not be [ignored by default](https://github.com/apple/swift-package-manager/pull/2209) it probably should be listed in the template as opt-in pattern.

The `xcuserdata` subdirectories are something one absolutely would want to ignore, but that's already covered by the template's `xcuserdata/` pattern.